### PR TITLE
Various code cleanups

### DIFF
--- a/hotp.php
+++ b/hotp.php
@@ -63,9 +63,9 @@ class HOTP {
      * @param int $min the minimum window to accept before $timestamp
      * @param int $max the maximum window to accept after $timestamp
      * @param int $timestamp a timestamp to calculate for, defaults to time()
-     * @return HOTPResult a HOTP Result which can be truncated or output
+     * @return array of HOTPResult
      */
-    public static function generateByTimeWindow($key, $window, $min, $max, $timestamp = false) {
+    public static function generateByTimeWindow($key, $window, $min = -1, $max = 1, $timestamp = false) {
         if (!$timestamp && $timestamp !== 0) {
             $timestamp = HOTP::getTime();
         }
@@ -73,6 +73,7 @@ class HOTP {
         $counter = intval($timestamp / $window);
         $window = range($min, $max);
         
+        $out = array();
         for ($i = 0; $i < count($window); $i++) {
             $shift_counter = $window[$i];
             $out[$shift_counter] = HOTP::generateByCounter($key, $counter + $shift_counter);


### PR DESCRIPTION
Fix a warning when no timezone is set causes a warning when timezones aren't set. PHP uses libc for this and its timezone agnostic.

Line of code in PHP's source shows that it ignores timezone.
http://svn.php.net/viewvc/php/php-src/branches/PHP_5_3/ext/date/php_date.c?revision=315779&view=markup#l1678

I also spoke to Derick who wrote the date extension, confirmed its not used.

Added a BSD license to the header.

Set some sensible defaults for generating a window and fix a notice there.
