### PR TITLE
Feat: Adds php-cs-fixer on commit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .github/ export-ignore
+.php-cs-fixer.php export-ignore
 composer.json export-ignore
 example.php export-ignore
 phpunit.xml export-ignore

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -5,7 +5,8 @@ on:
   pull_request:
 
 jobs:
-  run:
+  run-ci:
+    name: PHP ${{ matrix.php-versions }} test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -15,21 +16,16 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
-
-    name: PHP ${{ matrix.php-versions }} test
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup PHP with XDebug
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-versions }}
-        coverage: xdebug
-        tools: composer
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
-
-    - name: Run tests
-      run: composer test
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP with XDebug
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: xdebug
+          tools: composer
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+      - name: Run tests
+        run: composer test

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,14 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->exclude("tests")
+    ->exclude("vendor")
+    ->in(__DIR__);
+
+$config = new PhpCsFixer\Config();
+
+return $config->setRules([
+    '@PSR12' => true,
+    'trailing_comma_in_multiline' => true,
+])->setUsingCache(false)
+    ->setFinder($finder);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+# next (planned @ 2.0.1)
+- Adopts PSR-12 syntax everywhere (:heart: [jrzepa](https://github.com/jrzepa))
+- Expands version range for phpunit to ensure tests run against 7.2 [#16](https://github.com/jakobo/hotp-php/pull/16)
+
+# 2.0.0 (Dec 20, 2020)
+- Code coverage reporting added (:heart: [reedy](https://github.com/reedy))
+- Documentation updates and return type hints (:heart: [reedy](https://github.com/reedy))
+- Github CI Support [ac0d8d](https://github.com/jakobo/hotp-php/commit/ac0d8d0d64adc5f7ef83952bde25425bf74184cf) (:heart: [legoktm](https://github.com/legoktm))
+
+## Breaking Changes
+- **Bump minimum version** - To stay current, the minimum version was bumped from 5.3.3 to 7.2. We encourage you to update your PHP version to stay on top of potential security vulnerabilities and receive the latest performance and bug fixes.
+
+# 1.0.1 (Apr 11, 2019)
+- Token replay mitigation [d24e0d](https://github.com/jakobo/hotp-php/commit/d24e0d021710718cb9104ffb5c6ffb447fce65ab) (:heart: [reedy](https://github.com/reedy))
+- Created `composer.json` and made available through composer (:heart: [reedy](https://github.com/reedy))
+
+# 1.0.0
+- [reedy](https://github.com/reedy) joined the maintainer team
+- Initial Release with a tag

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,37 @@
         "php": ">=7.2"
     },
     "require-dev": {
-        "ockcyp/covers-validator": "1.3.3",
-        "phpunit/phpunit": "^8.5.13||^9.5.0",
+        "ockcyp/covers-validator": "^1.3.3",
+        "phpunit/phpunit": "^6.5.14||^7.0.15||^8.5.13||^9.5.0",
         "php-parallel-lint/php-console-highlighter": "0.5",
-        "php-parallel-lint/php-parallel-lint": "1.3.1"
+        "php-parallel-lint/php-parallel-lint": "1.3.1",
+        "friendsofphp/php-cs-fixer": "^3.4||^3.5||^3.6",
+        "brainmaestro/composer-git-hooks": "^2.8"
     },
     "scripts": {
+        "post-install-cmd": "cghooks add --ignore-lock",
+        "post-update-cmd": "cghooks update",
         "test": [
             "parallel-lint . --exclude vendor",
             "covers-validator",
             "phpunit --coverage-text"
         ],
-        "cover": "phpunit --coverage-html coverage"
+        "cover": "phpunit --coverage-html coverage",
+        "cghooks": "vendor/bin/cghooks",
+        "fix": "php-cs-fixer fix --config=.php-cs-fixer.php"
+    },
+    "extra": {
+        "hooks": {
+            "config": {
+                "stop-on-failure": ["pre-commit"]
+            },
+            "pre-commit": [
+                "composer run-script fix",
+                "git update-index --again :/:"
+            ],
+            "post-merge": [
+                "composer install"
+            ]
+        }
     }
 }

--- a/example.php
+++ b/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * HOTP Example File
  */

--- a/example.php
+++ b/example.php
@@ -106,24 +106,23 @@ echo "Count Method Value                                           Pass/Fail\n";
 echo "----------------------------------------------------------------------\n";
 
 // loop over all HOTP table results, and calculate the matching value
-foreach ( $table['HOTP'] as $seed => $results ) {
-    $hotp = HOTP::generateByCounter( $key, $seed );
+foreach ($table['HOTP'] as $seed => $results) {
+    $hotp = HOTP::generateByCounter($key, $seed);
     $first = true;
-    foreach ( $results as $type => $calc ) {
-        if ( $first ) {
-            echo str_pad( $seed, 4, ' ', STR_PAD_LEFT );
+    foreach ($results as $type => $calc) {
+        if ($first) {
+            echo str_pad($seed, 4, ' ', STR_PAD_LEFT);
             $first = false;
-        }
-        else {
+        } else {
             echo '    ';
         }
         echo '  ';
-        echo str_pad( $type, 5, ' ', STR_PAD_RIGHT);
+        echo str_pad($type, 5, ' ', STR_PAD_RIGHT);
         echo '  ';
-        echo str_pad( $calc, 47, ' ', STR_PAD_RIGHT);
+        echo str_pad($calc, 47, ' ', STR_PAD_RIGHT);
         echo '  ';
-        $method = 'to' . ( ucfirst( str_replace( 'HMAC', 'string', $type ) ) );
-        echo str_pad( ( $calc == $hotp->$method( 6 ) ) ? '[OK]' : '[FAIL]', 9, ' ', STR_PAD_LEFT );
+        $method = 'to' . (ucfirst(str_replace('HMAC', 'string', $type)));
+        echo str_pad(($calc == $hotp->$method(6)) ? '[OK]' : '[FAIL]', 9, ' ', STR_PAD_LEFT);
         echo "\n";
     }
 }
@@ -138,22 +137,21 @@ echo "Time (sec)   Value                                           Pass/Fail\n";
 echo "----------------------------------------------------------------------\n";
 
 // now echo over the TOTP table
-foreach ( $table['TOTP'] as $seed => $results ) {
-    $totp = HOTP::generateByTime( $key, 30, $seed );
+foreach ($table['TOTP'] as $seed => $results) {
+    $totp = HOTP::generateByTime($key, 30, $seed);
     $first = true;
-    foreach ( $results as $type => $calc ) {
-        if ( $first ) {
-            echo str_pad( $seed, 10, ' ', STR_PAD_LEFT );
+    foreach ($results as $type => $calc) {
+        if ($first) {
+            echo str_pad($seed, 10, ' ', STR_PAD_LEFT);
             $first = false;
-        }
-        else {
+        } else {
             echo '          ';
         }
         echo '   ';
-        echo str_pad( $calc, 47, ' ', STR_PAD_RIGHT );
+        echo str_pad($calc, 47, ' ', STR_PAD_RIGHT);
         echo '  ';
-        $method = 'to' . ( ucfirst( str_replace( 'totp', 'hotp', $type ) ) );
-        echo str_pad( ( $calc == $totp->$method( 8 ) ) ? '[OK]' : '[FAIL]', 9, ' ', STR_PAD_LEFT );
+        $method = 'to' . (ucfirst(str_replace('totp', 'hotp', $type)));
+        echo str_pad(($calc == $totp->$method(8)) ? '[OK]' : '[FAIL]', 9, ' ', STR_PAD_LEFT);
         echo "\n";
     }
 }

--- a/src/HOTP.php
+++ b/src/HOTP.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace jakobo\HOTP;
 
 /**

--- a/src/HOTPResult.php
+++ b/src/HOTPResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace jakobo\HOTP;
 
 /**
@@ -83,7 +85,7 @@ class HOTPResult
      */
     public function toHOTP(int $length): string
     {
-        $str = str_pad($this->toDec(), $length, "0", STR_PAD_LEFT);
+        $str = str_pad((string)$this->toDec(), $length, "0", STR_PAD_LEFT);
         return substr($str, (-1 * $length));
     }
 }

--- a/tests/HOTPTest.php
+++ b/tests/HOTPTest.php
@@ -23,7 +23,7 @@ class HOTPTest extends TestCase
                     'hex'   => '4c93cf18',
                     'dec'   => '1284755224',
                     'hotp'  => '755224',
-                ]
+                ],
             ],
             [
                 1, [
@@ -31,7 +31,7 @@ class HOTPTest extends TestCase
                     'hex'   => '41397eea',
                     'dec'   => '1094287082',
                     'hotp'  => '287082',
-                ]
+                ],
             ],
             [
                 2, [
@@ -39,7 +39,7 @@ class HOTPTest extends TestCase
                     'hex'   => '82fef30',
                     'dec'   => '137359152',
                     'hotp'  => '359152',
-                ]
+                ],
             ],
             [
                 3, [
@@ -47,7 +47,7 @@ class HOTPTest extends TestCase
                     'hex'   => '66ef7655',
                     'dec'   => '1726969429',
                     'hotp'  => '969429',
-                ]
+                ],
             ],
             [
                 4, [
@@ -55,7 +55,7 @@ class HOTPTest extends TestCase
                     'hex'   => '61c5938a',
                     'dec'   => '1640338314',
                     'hotp'  => '338314',
-                ]
+                ],
             ],
             [
                 5, [
@@ -63,7 +63,7 @@ class HOTPTest extends TestCase
                     'hex'   => '33c083d4',
                     'dec'   => '868254676',
                     'hotp'  => '254676',
-                ]
+                ],
             ],
             [
                 6, [
@@ -71,7 +71,7 @@ class HOTPTest extends TestCase
                     'hex'   => '7256c032',
                     'dec'   => '1918287922',
                     'hotp'  => '287922',
-                ]
+                ],
             ],
             [
                 7, [
@@ -79,7 +79,7 @@ class HOTPTest extends TestCase
                     'hex'   => '4e5b397',
                     'dec'   => '82162583',
                     'hotp'  => '162583',
-                ]
+                ],
             ],
             [
                 8, [
@@ -87,7 +87,7 @@ class HOTPTest extends TestCase
                     'hex'   => '2823443f',
                     'dec'   => '673399871',
                     'hotp'  => '399871',
-                ]
+                ],
             ],
             [
                 9, [
@@ -95,7 +95,7 @@ class HOTPTest extends TestCase
                     'hex'   => '2679dc69',
                     'dec'   => '645520489',
                     'hotp'  => '520489',
-                ]
+                ],
             ],
         ];
     }
@@ -177,9 +177,9 @@ class HOTPTest extends TestCase
                     "266759",
                     "306183",
                     "466594",
-                    "754889"
-                ]
-            ]
+                    "754889",
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
This builds on #13 and adds an on-commit hook using the composer-git-hooks library. It's not foolproof, but it offers some consistency in ensuring code is cleaned up to a common format when committed. Obviously VSCode and other tools do this for us, but if you're using a non PSR-12 editor, it's nice that the code is being cleaned up on commit.

**EDIT** There's a couple of additional changes required to make this work
- PSR-12 formatting works now that trailing commas are allowed
- Versions for existing libraries were widened to ensure coverage and tests can run in the 7.2 environment
- Commit hooks use git's update index to re-add only staged files if changed

Resolves #14