### PR TITLE
fix: Uses an idempotent padding operation to avoid a code branch

### DIFF
--- a/src/HOTP.php
+++ b/src/HOTP.php
@@ -34,12 +34,7 @@ class HOTP
         $binCounter = implode($curCounter);
 
         // Pad to 8 chars
-        if (strlen($binCounter) < 8) {
-            $binCounter = str_repeat(
-                chr(0),
-                8 - strlen($binCounter)
-            ) . $binCounter;
-        }
+        $binCounter = str_pad(implode("", $curCounter), 8, chr(0), STR_PAD_LEFT);
 
         // HMAC
         $hash = hash_hmac('sha1', $binCounter, $key);


### PR DESCRIPTION
Because we want to ensure the length of of our binCounter is 8, we previously used an if block coupled with a str_repeat operation. After this change, we are making a str_pad check which can run without the encompassing if logic. This moves us to 100% code coverage.

Fixes #12